### PR TITLE
display_template bug on php 7.2

### DIFF
--- a/src/bento.php
+++ b/src/bento.php
@@ -1071,14 +1071,14 @@ function p($string, $force = false)
  * @param string $file PHP template file
  * @param array  $data Array of key-value template data
  */
-function display_template($file, $data = array())
+function display_template()
 {
-    if (!is_readable($file)) {
+    if (!is_readable(func_get_arg(0))) { 
         throw new \RuntimeException(sprintf(
-            'template file %s is not readable', $file
+            'template file %s is not readable', func_get_arg(0)
         ));
-    }
-    extract($data);
+    } 
+    extract(func_get_arg(1));
     include func_get_arg(0);
 }
 


### PR DESCRIPTION
it's hard to say if this is a bug with php or otherwise, 
but at least since 7.2 (possibly earlier, this is what i'm 
testing with), if you had an item in $data with the key
'file' it would overwrite the $file variable with the use
of extract(), including when you access it with
func_get_arg(0). this is a solution that doesn't use
parameter names at all to achieve the same result,
so it avoids the problem.

the previous code worked well on 5.6, but i've
(finally) upgraded from my toy server to a modern
php, and just so happened to have a 'file' item in
the $data array in at least one place i use it.